### PR TITLE
016/store data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ To run unit tests, configure by running `npm install --save-dev @babel/core @bab
 TBD, but your first clue is that I don't mind the source being public :-)
 
  
- 
+

--- a/__tests__/common/pickling/typedArray.test.mjs
+++ b/__tests__/common/pickling/typedArray.test.mjs
@@ -1,0 +1,17 @@
+import { TypedArray } from "../../../common/pickling/typedArray.js";
+
+test('Create TypedArray from permitted types', () => {
+    const testArray = new TypedArray();
+    testArray.push(null);
+    testArray.push(2);
+    testArray.push(2.25);
+    testArray.push("linger");
+    expect(testArray).toMatchObject([null, 2, 2.25, "linger"]);
+});
+
+test('typedArray with created with a Map throws a TypeError', () => {
+    expect( () => {
+        const testArray = new TypedArray();
+        testArray.push(new Map());
+    } ).toThrow(TypeError);
+});

--- a/__tests__/common/pickling/typedContainer.test.mjs
+++ b/__tests__/common/pickling/typedContainer.test.mjs
@@ -1,0 +1,47 @@
+import { TypedContainer } from "../../../common/pickling/typedContainer.js";
+import { TypedArray } from "../../../common/pickling/typedArray";
+
+
+function getTestArray() {
+    const arr = new TypedArray();
+    arr.push("abc123");
+    arr.push(null);
+    arr.push(false);
+    return arr;
+}
+
+function getTestContainer() {
+    const container = new TypedContainer();
+    container.set("hello", getTestArray());
+    const subContainer = new TypedContainer();
+    subContainer.set("a", 321);
+    subContainer.set("b", true);
+
+    container.set("goodbye", subContainer);
+
+    return container;
+}
+
+const EXPECTED_SERIALIZATION =
+{   
+    "hello": ["abc123",null,false],
+    "goodbye": {"a":321, 
+                "b":true
+               }
+}
+
+test('Roundtrip JSON serialization with a TypedContainer works', () => {
+    const container = getTestContainer();
+    
+    const jsonString = JSON.stringify(container);
+    const jsonParsed = JSON.parse(jsonString);
+
+    expect(jsonParsed).toMatchObject(EXPECTED_SERIALIZATION);
+});
+
+test('typedContainer with created with a Map throws a TypeError', () => {
+    expect( () => {
+        const testContainer = new TypedContainer();
+        testContainer.set("myMap", new Map());
+    } ).toThrow(TypeError);
+});

--- a/__tests__/common/pickling/typedContainer.test.mjs
+++ b/__tests__/common/pickling/typedContainer.test.mjs
@@ -39,6 +39,12 @@ test('Roundtrip JSON serialization with a TypedContainer works', () => {
     expect(jsonParsed).toMatchObject(EXPECTED_SERIALIZATION);
 });
 
+test('TypedContainer get works', () => {
+    const container = getTestContainer();
+
+    expect(container.get("hello")).toMatchObject(["abc123",null,false]);
+});
+
 test('typedContainer with created with a Map throws a TypeError', () => {
     expect( () => {
         const testContainer = new TypedContainer();

--- a/__tests__/common/pickling/typedSet.test.mjs
+++ b/__tests__/common/pickling/typedSet.test.mjs
@@ -1,0 +1,13 @@
+import { TypedSet } from "../../../common/pickling/typedSet.js";
+
+const EXPECTED_ARRAY = [1,6,"Hello",null];
+
+test('TypedSet promptly de-dupes valid types', () => {
+    const testSet = new TypedSet([1,1,1,6,6,6,"Hello", "Hello",null,6,1,6,null]);
+    const resultObject = JSON.parse(testSet.toJsonString());
+    expect(resultObject).toMatchObject(EXPECTED_ARRAY);
+});
+
+test('TypedSet catches invalid types', () => {
+    expect( () => {new TypedSet([2,new Map()])} ).toThrow(TypeError);
+});

--- a/common/pickling/localStoragePickle.js
+++ b/common/pickling/localStoragePickle.js
@@ -1,0 +1,8 @@
+class LocalStoragePickle {
+    constructor() {
+    }
+
+    
+
+
+}

--- a/common/pickling/localStoragePickle.js
+++ b/common/pickling/localStoragePickle.js
@@ -14,7 +14,6 @@ class LocalStoragePickle {
 
     deserialize(value) {
         const deserialized = JSON.parse(value);
-        console.log("Deserialized: ", deserialized);
         return JSON.parse(value);
     }
 
@@ -24,7 +23,6 @@ class LocalStoragePickle {
 
     get (key) {
         const retrieved = localStorage.getItem(key);
-        console.log(`Retrieved for key ${key}`, retrieved);
         return this.deserialize(retrieved);
     }
 
@@ -39,8 +37,7 @@ class LocalStoragePickle {
 
     retrieveSet(key) {
         const setKey = `${this.setPrefix}${key}`;
-        const retrieved = this.get(setKey);
-        console.log("retrieved in retrieveSet: ", retrieved);
+        const retrieved = this.deserialize(this.get(setKey));
         return new TypedSet(retrieved);
     }
     

--- a/common/pickling/localStoragePickle.js
+++ b/common/pickling/localStoragePickle.js
@@ -1,5 +1,6 @@
 import { isPickleable, testPickleable } from "./utils.js";
 import { TypedArray } from "./typedArray.js";
+import { TypedSet } from "./typedSet.js";
 
 class LocalStoragePickle {
     constructor() {
@@ -24,7 +25,21 @@ class LocalStoragePickle {
         return this.deserialize(retrieved);
     }
 
+    storeSet(key, typedSet) {
+        if (!(typedSet instanceof TypedSet)) {
+            throw new TypeError("Must add a typed set!");
+        }
+
+        const setKey = `${this.setPrefix}${key}`;
+        this.set(setKey, typedSet.toJsonString());
+    }
+
+    retrieveSet(key) {
+        const setKey = `${this.setPrefix}${key}`;
+        const retrieved = this.get(setKey);
+        return new TypedSet(retrieved);
+    }
     
-
-
 }
+
+export { LocalStoragePickle }

--- a/common/pickling/localStoragePickle.js
+++ b/common/pickling/localStoragePickle.js
@@ -1,5 +1,27 @@
+import { isPickleable, testPickleable } from "./utils.js";
+import { TypedArray } from "./typedArray.js";
+
 class LocalStoragePickle {
     constructor() {
+        this.setPrefix = "_typedSet_";
+    }
+
+    serialize(value) {
+        testPickleable(value);
+        return JSON.stringify(value);
+    }
+
+    deserialize(value) {
+        return JSON.parse(value);
+    }
+
+    set(key, value) {
+        localStorage.setItem(key, this.serialize(value));
+    }
+
+    get (key) {
+        const retrieved = localStorage.getItem(key);
+        return this.deserialize(retrieved);
     }
 
     

--- a/common/pickling/localStoragePickle.js
+++ b/common/pickling/localStoragePickle.js
@@ -13,6 +13,8 @@ class LocalStoragePickle {
     }
 
     deserialize(value) {
+        const deserialized = JSON.parse(value);
+        console.log("Deserialized: ", deserialized);
         return JSON.parse(value);
     }
 
@@ -22,6 +24,7 @@ class LocalStoragePickle {
 
     get (key) {
         const retrieved = localStorage.getItem(key);
+        console.log(`Retrieved for key ${key}`, retrieved);
         return this.deserialize(retrieved);
     }
 
@@ -37,6 +40,7 @@ class LocalStoragePickle {
     retrieveSet(key) {
         const setKey = `${this.setPrefix}${key}`;
         const retrieved = this.get(setKey);
+        console.log("retrieved in retrieveSet: ", retrieved);
         return new TypedSet(retrieved);
     }
     

--- a/common/pickling/typedArray.js
+++ b/common/pickling/typedArray.js
@@ -2,6 +2,9 @@ import { setPickleable, testPickleable } from "./utils.js";
 
 class TypedArray extends Array {
     constructor(...args) {
+        for (const arg of args) {
+            testPickleable(arg);
+        }
         super(...args);
         setPickleable(this);
     }

--- a/common/pickling/typedArray.js
+++ b/common/pickling/typedArray.js
@@ -1,0 +1,15 @@
+import { setPickleable, testPickleable } from "./utils.js";
+
+class TypedArray extends Array {
+    constructor(...args) {
+        super(...args);
+        setPickleable(this);
+    }
+
+    push(obj) {
+        testPickleable(obj);
+        super.push(obj);
+    }
+}
+
+export { TypedArray }

--- a/common/pickling/typedContainer.js
+++ b/common/pickling/typedContainer.js
@@ -1,0 +1,20 @@
+import { testPickleable, setPickleable } from "./utils.js";
+
+class TypedContainer extends Object {
+
+    constructor(...args) {
+        super(...args);
+        setPickleable(this);
+    }
+
+    set(propertyName, value) {
+        testPickleable(value);
+        this[propertyName] = value;
+    }
+
+    get(propertyName) {
+        return this[propertyName];
+    }
+}
+
+export { TypedContainer };

--- a/common/pickling/typedSet.js
+++ b/common/pickling/typedSet.js
@@ -1,11 +1,16 @@
-import { testPickleable } from "./utils";
+import { testPickleable } from "./utils.js";
 
 class TypedSet extends Set {
     constructor(initialSet) {
-        for (const item of initialSet) {
-            testPickleable(item);
+        if (initialSet === null || initialSet === undefined)  {
+            super(initialSet);
+        } else {
+            for (const item of initialSet) {
+                testPickleable(item);
+            }
+            console.log("Calling Set constructor on ...", initialSet);
+            super(initialSet);    
         }
-        super(initialSet);
     }
 
     add(item) {

--- a/common/pickling/typedSet.js
+++ b/common/pickling/typedSet.js
@@ -5,12 +5,10 @@ class TypedSet extends Set {
         if (initialSet === null || initialSet === undefined)  {
             super(initialSet);
         } else {
-            console.log("Else statement; initialSet was ", initialSet);
             for (const item of initialSet) {
                 testPickleable(item);
             }
-            console.log("Calling Set constructor on ...", initialSet);
-            super(initialSet);    // is this the problem line? can we just add the items individually???
+            super(initialSet);
         }
     }
 

--- a/common/pickling/typedSet.js
+++ b/common/pickling/typedSet.js
@@ -1,0 +1,21 @@
+import { testPickleable } from "./utils";
+
+class TypedSet extends Set {
+    constructor(initialSet) {
+        for (const item of initialSet) {
+            testPickleable(item);
+        }
+        super(initialSet);
+    }
+
+    add(item) {
+        testPickleable(item);
+        super.add(item);
+    }
+
+    toJsonString() {
+        return JSON.stringify(Array.from(this));
+    }
+}
+
+export { TypedSet }

--- a/common/pickling/typedSet.js
+++ b/common/pickling/typedSet.js
@@ -5,11 +5,12 @@ class TypedSet extends Set {
         if (initialSet === null || initialSet === undefined)  {
             super(initialSet);
         } else {
+            console.log("Else statement; initialSet was ", initialSet);
             for (const item of initialSet) {
                 testPickleable(item);
             }
             console.log("Calling Set constructor on ...", initialSet);
-            super(initialSet);    
+            super(initialSet);    // is this the problem line? can we just add the items individually???
         }
     }
 

--- a/common/pickling/utils.js
+++ b/common/pickling/utils.js
@@ -1,0 +1,38 @@
+const PERMITTED_TYPES = ["string", "boolean", "number"];
+
+const PICKLEABLE_FLAG = "_isPickleable";
+
+function setPickleable(obj) {
+    Object.defineProperty(obj, PICKLEABLE_FLAG, {
+        writable: false,
+        enumerable: false,
+        value: true
+    })
+}
+
+function isPickleable(obj) {
+    console.log("Testing this obj", obj);
+    if (obj === null) {
+        return true;
+    }
+
+    for (const type of PERMITTED_TYPES) {
+        if (typeof obj === type) {
+            return true;
+        }
+    }
+
+    if (obj[PICKLEABLE_FLAG] === true) {
+        return true;
+    }
+
+    return false;
+}
+
+function testPickleable(obj) {
+    if (!isPickleable(obj)) {
+        throw new TypeError(`Can't pickle ${JSON.stringify(obj)}`);s
+    }
+}
+
+export { isPickleable, testPickleable, setPickleable }

--- a/common/pickling/utils.js
+++ b/common/pickling/utils.js
@@ -11,7 +11,6 @@ function setPickleable(obj) {
 }
 
 function isPickleable(obj) {
-    console.log("Testing this obj", obj);
     if (obj === null) {
         return true;
     }

--- a/common/pickling/utils.js
+++ b/common/pickling/utils.js
@@ -11,6 +11,7 @@ function setPickleable(obj) {
 }
 
 function isPickleable(obj) {
+
     if (obj === null) {
         return true;
     }

--- a/demodisplay/picklingdemo/index.html
+++ b/demodisplay/picklingdemo/index.html
@@ -8,7 +8,7 @@
         <div id="Whatever">
 
         </div>
-        <div id="Whatever2">
+        <div id="Whatever2" style="word-wrap: break-word;">
             
         </div>
     </body>

--- a/demodisplay/picklingdemo/index.html
+++ b/demodisplay/picklingdemo/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <script src="./picklingtest.js" type="module"></script>
+    <head>
+
+    </head>
+    <body>
+        <div id="Whatever">
+
+        </div>
+        <div id="Whatever2">
+            
+        </div>
+    </body>
+</html>

--- a/demodisplay/picklingdemo/picklingtest.js
+++ b/demodisplay/picklingdemo/picklingtest.js
@@ -1,0 +1,43 @@
+import { LocalStoragePickle } from "../../common/pickling/localStoragePickle.js";
+import { TypedArray } from "../../common/pickling/typedArray.js";
+import { TypedSet } from "../../common/pickling/typedSet.js";
+
+const pickle = new LocalStoragePickle();
+
+const setName = "mySet";
+pickle.storeSet(setName, new TypedSet());
+pickle.set("Raul", "Lua R.");
+const element = document.getElementById("Whatever");
+element.innerText = pickle.get("Raul");
+const secondElement = document.getElementById("Whatever2");
+
+
+function augment() {
+    const mySet = pickle.retrieveSet(setName);
+    console.log("mySet: ",mySet,"mySet.size: ",`${mySet.size}`);
+    if (mySet.size == 0) {
+        mySet.add(1);
+    } else {
+        console.log(mySet);
+        const arr = Array.from(mySet);
+        const last = arr.at(-1);
+        mySet.add(last + 4);
+        mySet.add(1);
+        mySet.add(last + 4);
+        mySet.add(last + 4);
+        mySet.add(last + 4);
+    }
+
+    return mySet;
+}
+
+function refresher() {
+    const newSet = augment();
+    secondElement.innerText=newSet.toJsonString();
+    console.log(`Cycling, ${newSet.toJsonString()}...`);
+    pickle.storeSet(setName, newSet);
+}
+
+setInterval(refresher, 2000);
+
+export { pickle, augment }

--- a/demodisplay/picklingdemo/picklingtest.js
+++ b/demodisplay/picklingdemo/picklingtest.js
@@ -4,21 +4,21 @@ import { TypedSet } from "../../common/pickling/typedSet.js";
 
 const pickle = new LocalStoragePickle();
 
-const setName = "mySet";
-pickle.storeSet(setName, new TypedSet());
+// Setup
 pickle.set("Raul", "Lua R.");
 const element = document.getElementById("Whatever");
 element.innerText = pickle.get("Raul");
 const secondElement = document.getElementById("Whatever2");
 
+// Set property
+const setName = "mySet";
+
 
 function augment() {
     const mySet = pickle.retrieveSet(setName);
-    console.log("mySet: ",mySet,"mySet.size: ",`${mySet.size}`);
     if (mySet.size == 0) {
         mySet.add(1);
     } else {
-        console.log(mySet);
         const arr = Array.from(mySet);
         const last = arr.at(-1);
         mySet.add(last + 4);
@@ -34,7 +34,6 @@ function augment() {
 function refresher() {
     const newSet = augment();
     secondElement.innerText=newSet.toJsonString();
-    console.log(`Cycling, ${newSet.toJsonString()}...`);
     pickle.storeSet(setName, newSet);
 }
 


### PR DESCRIPTION
* create classes that serialize to clean JSON (`TypedContainer` is map-like, `TypedArray` extends `Array`, `TypedSet` extends `Set`)
* create a `LocalStoragePickle` class to leverage serializing these classes to `localStorage`
* add special methods so that we can roundtrip sets to plain JSON arrays